### PR TITLE
SSL support for Hacker News

### DIFF
--- a/hn/selectivity.user.js
+++ b/hn/selectivity.user.js
@@ -3,6 +3,7 @@
 // @namespace      http://swapped.cc/iip
 // @description    Adds a "hide" option to the stories on the Hacker News front page.
 // @include        http://news.ycombinator.com/*
+// @include        https://news.ycombinator.com/*
 // @require        http://code.jquery.com/jquery-1.5.2.min.js
 // @require        https://raw.github.com/apankrat/internet-improvement-project/master/_shared/js/gm-xhr.js
 // @require        https://raw.github.com/apankrat/internet-improvement-project/master/_shared/js/jquery.color.min.js


### PR DESCRIPTION
Hacker News has an [SSL version](https://news.ycombinator.com), but Selectivity for HN doesn't currently trigger on it.  I've included a pretty trivial commit to add an https include rule for Greasemonkey, but I'm not familiar enough with Chrome extensions to tinker with that part.
